### PR TITLE
Make waitFor throw InterruptedException.

### DIFF
--- a/src/main/java/org/pircbotx/hooks/WaitForQueue.java
+++ b/src/main/java/org/pircbotx/hooks/WaitForQueue.java
@@ -130,7 +130,8 @@ public class WaitForQueue implements Closeable {
 			Event curEvent = eventQueue.poll(timeout, unit);
 			//When poll times out it returns null. Repeat that behavior here
 			if (curEvent == null)
-				return null;
+				//return null;
+				throw new InterruptedException();
 			for (Class<? extends GenericEvent> curEventClass : eventClasses)
 				if (curEventClass.isInstance(curEvent))
 					return curEvent;


### PR DESCRIPTION
Queues with timeout should throw InterruptedException exceptions rather than returning null.
