### PR TITLE
Add OSGi metadata to manifest.

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-SymbolicName: org.pircbotx
+-exportcontents: \
+	org.pircbotx*

--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,28 @@
 					</execution>
 				</executions>
 			</plugin>
+			<!-- Generate OSGi manifest metadata -->
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<version>2.4.1</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>bnd-process</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<!-- Use OSGi manifest instead of generating an empty one -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>2.6</version>
+				<configuration>
+					<useDefaultManifestFile>true</useDefaultManifestFile>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
This change adds some metadata to the MANIFEST.MF file that allows pircbotx to be used in OSGi environments like Eclipse Equinox or Apache Felix.
