### PR TITLE
added to builder: nickservCustomMessage, nickservDelayJoinTime and userModeHideRealHost

### DIFF
--- a/src/main/java/org/pircbotx/Configuration.java
+++ b/src/main/java/org/pircbotx/Configuration.java
@@ -63,7 +63,7 @@ import org.pircbotx.output.OutputUser;
  * @author Leon Blakey
  */
 @Data
-@ToString(exclude = {"serverPassword", "nickservPassword"})
+@ToString(exclude = {"serverPassword", "nickservPassword", "nickservCustomMessage"})
 public class Configuration {
 	//WebIRC
 	protected final boolean webIrcEnabled;
@@ -108,7 +108,10 @@ public class Configuration {
 	protected final String nickservPassword;
 	protected final String nickservOnSuccess;
 	protected final String nickservNick;
+	protected final String nickservCustomMessage;
 	protected final boolean nickservDelayJoin;
+	protected final int nickservDelayJoinTime;
+	protected final boolean userModeHideRealHost;
 	protected final boolean autoReconnect;
 	protected final int autoReconnectDelay;
 	protected final int autoReconnectAttempts;
@@ -162,8 +165,11 @@ public class Configuration {
 				throw new RuntimeException("Channel must not be blank");
 		if (builder.getNickservPassword() != null)
 			checkArgument(StringUtils.isNotBlank(builder.getNickservPassword()), "Nickserv password cannot be empty");
+		if (builder.getNickservCustomMessage() != null)
+			checkArgument(StringUtils.isNotBlank(builder.getNickservCustomMessage()), "Nickserv custom message cannot be empty");
 		checkArgument(StringUtils.isNotBlank(builder.getNickservOnSuccess()), "Nickserv on success cannot be blank");
 		checkArgument(StringUtils.isNotBlank(builder.getNickservNick()), "Nickserv nick cannot be blank");
+		checkArgument(builder.getNickservDelayJoinTime() >= 0, "setNickServDelayJoinTime must be greater then 0");
 		checkArgument(builder.getAutoReconnectAttempts() > 0, "setAutoReconnectAttempts must be greater than 0");
 		checkArgument(builder.getAutoReconnectDelay() >= 0, "setAutoReconnectDelay must be positive or 0");
 		checkNotNull(builder.getListenerManager(), "Must specify listener manager");
@@ -207,7 +213,10 @@ public class Configuration {
 		this.nickservPassword = builder.getNickservPassword();
 		this.nickservOnSuccess = builder.getNickservOnSuccess();
 		this.nickservNick = builder.getNickservNick();
+		this.nickservCustomMessage = builder.getNickservCustomMessage();
 		this.nickservDelayJoin = builder.isNickservDelayJoin();
+		this.nickservDelayJoinTime = builder.getNickservDelayJoinTime();
+		this.userModeHideRealHost = builder.isUserModeHideRealHost();
 		this.autoReconnect = builder.isAutoReconnect();
 		this.autoReconnectDelay = builder.getAutoReconnectDelay();
 		this.autoReconnectAttempts = builder.getAutoReconnectAttempts();
@@ -449,10 +458,25 @@ public class Configuration {
 		 */
 		protected String nickservNick = "nickserv";
 		/**
+		 * Some irc servers require a custom identify string.
+		 * eg: Quakenet: <code>PRIVMSG Q@CServe.quakenet.org :AUTH USER PASS</code>
+		 * default = null
+		 */
+		protected String nickservCustomMessage = null;
+		/**
 		 * Delay joining channels until were identified to nickserv, default
 		 * false
 		 */
 		protected boolean nickservDelayJoin = false;
+		/**
+		 * Set custom delay before joining channels after being identified to nickserv, default
+		 * 0
+		 */
+		protected int nickservDelayJoinTime = 0;
+		/**
+		 * Sets mode +x on the bot, to hide the real hostname, default = false
+		 */
+		protected boolean userModeHideRealHost = false;
 		/**
 		 * Enable or disable automatic reconnecting, default false. Note that
 		 * you MUST call {@link PircBotX#stopBotReconnect() } when you do not
@@ -546,7 +570,10 @@ public class Configuration {
 			this.nickservPassword = configuration.getNickservPassword();
 			this.nickservOnSuccess = configuration.getNickservOnSuccess();
 			this.nickservNick = configuration.getNickservNick();
+			this.nickservCustomMessage = configuration.getNickservCustomMessage();
 			this.nickservDelayJoin = configuration.isNickservDelayJoin();
+			this.nickservDelayJoinTime = configuration.getNickservDelayJoinTime();
+			this.userModeHideRealHost = configuration.isUserModeHideRealHost();
 			this.autoReconnect = configuration.isAutoReconnect();
 			this.autoReconnectDelay = configuration.getAutoReconnectDelay();
 			this.autoReconnectAttempts = configuration.getAutoReconnectAttempts();
@@ -607,7 +634,10 @@ public class Configuration {
 			this.nickservPassword = otherBuilder.getNickservPassword();
 			this.nickservOnSuccess = otherBuilder.getNickservOnSuccess();
 			this.nickservNick = otherBuilder.getNickservNick();
+			this.nickservCustomMessage = otherBuilder.getNickservCustomMessage();
 			this.nickservDelayJoin = otherBuilder.isNickservDelayJoin();
+			this.nickservDelayJoinTime = otherBuilder.getNickservDelayJoinTime();
+			this.userModeHideRealHost = otherBuilder.isUserModeHideRealHost();
 			this.autoReconnect = otherBuilder.isAutoReconnect();
 			this.autoReconnectDelay = otherBuilder.getAutoReconnectDelay();
 			this.autoReconnectAttempts = otherBuilder.getAutoReconnectAttempts();

--- a/src/main/java/org/pircbotx/Configuration.java
+++ b/src/main/java/org/pircbotx/Configuration.java
@@ -110,7 +110,6 @@ public class Configuration {
 	protected final String nickservNick;
 	protected final String nickservCustomMessage;
 	protected final boolean nickservDelayJoin;
-	protected final int nickservDelayJoinTime;
 	protected final boolean userModeHideRealHost;
 	protected final boolean autoReconnect;
 	protected final int autoReconnectDelay;
@@ -169,7 +168,6 @@ public class Configuration {
 			checkArgument(StringUtils.isNotBlank(builder.getNickservCustomMessage()), "Nickserv custom message cannot be empty");
 		checkArgument(StringUtils.isNotBlank(builder.getNickservOnSuccess()), "Nickserv on success cannot be blank");
 		checkArgument(StringUtils.isNotBlank(builder.getNickservNick()), "Nickserv nick cannot be blank");
-		checkArgument(builder.getNickservDelayJoinTime() >= 0, "setNickServDelayJoinTime must be greater then 0");
 		checkArgument(builder.getAutoReconnectAttempts() > 0, "setAutoReconnectAttempts must be greater than 0");
 		checkArgument(builder.getAutoReconnectDelay() >= 0, "setAutoReconnectDelay must be positive or 0");
 		checkNotNull(builder.getListenerManager(), "Must specify listener manager");
@@ -215,7 +213,6 @@ public class Configuration {
 		this.nickservNick = builder.getNickservNick();
 		this.nickservCustomMessage = builder.getNickservCustomMessage();
 		this.nickservDelayJoin = builder.isNickservDelayJoin();
-		this.nickservDelayJoinTime = builder.getNickservDelayJoinTime();
 		this.userModeHideRealHost = builder.isUserModeHideRealHost();
 		this.autoReconnect = builder.isAutoReconnect();
 		this.autoReconnectDelay = builder.getAutoReconnectDelay();
@@ -469,11 +466,6 @@ public class Configuration {
 		 */
 		protected boolean nickservDelayJoin = false;
 		/**
-		 * Set custom delay before joining channels after being identified to nickserv, default
-		 * 0
-		 */
-		protected int nickservDelayJoinTime = 0;
-		/**
 		 * Sets mode +x on the bot, to hide the real hostname, default = false
 		 */
 		protected boolean userModeHideRealHost = false;
@@ -572,7 +564,6 @@ public class Configuration {
 			this.nickservNick = configuration.getNickservNick();
 			this.nickservCustomMessage = configuration.getNickservCustomMessage();
 			this.nickservDelayJoin = configuration.isNickservDelayJoin();
-			this.nickservDelayJoinTime = configuration.getNickservDelayJoinTime();
 			this.userModeHideRealHost = configuration.isUserModeHideRealHost();
 			this.autoReconnect = configuration.isAutoReconnect();
 			this.autoReconnectDelay = configuration.getAutoReconnectDelay();
@@ -636,7 +627,6 @@ public class Configuration {
 			this.nickservNick = otherBuilder.getNickservNick();
 			this.nickservCustomMessage = otherBuilder.getNickservCustomMessage();
 			this.nickservDelayJoin = otherBuilder.isNickservDelayJoin();
-			this.nickservDelayJoinTime = otherBuilder.getNickservDelayJoinTime();
 			this.userModeHideRealHost = otherBuilder.isUserModeHideRealHost();
 			this.autoReconnect = otherBuilder.isAutoReconnect();
 			this.autoReconnectDelay = otherBuilder.getAutoReconnectDelay();

--- a/src/main/java/org/pircbotx/InputParser.java
+++ b/src/main/java/org/pircbotx/InputParser.java
@@ -390,6 +390,8 @@ public class InputParser implements Closeable {
 				bot.sendIRC().identify(configuration.getNickservPassword());
 			if (configuration.getNickservCustomMessage() != null)
 				bot.sendRaw().rawLine(configuration.getNickservCustomMessage());
+			if (configuration.isUserModeHideRealHost())
+				bot.sendIRC().mode(bot.getNick(), "+x");
 			ImmutableMap<String, String> autoConnectChannels = bot.reconnectChannels();
 			if (autoConnectChannels == null)
 				if (configuration.isNickservDelayJoin())

--- a/src/main/java/org/pircbotx/InputParser.java
+++ b/src/main/java/org/pircbotx/InputParser.java
@@ -388,6 +388,8 @@ public class InputParser implements Closeable {
 			//Handle automatic on connect stuff
 			if (configuration.getNickservPassword() != null)
 				bot.sendIRC().identify(configuration.getNickservPassword());
+			if (configuration.getNickservCustomMessage() != null)
+				bot.sendRaw().rawLine(configuration.getNickservCustomMessage());
 			ImmutableMap<String, String> autoConnectChannels = bot.reconnectChannels();
 			if (autoConnectChannels == null)
 				if (configuration.isNickservDelayJoin())

--- a/src/main/java/org/pircbotx/hooks/CoreHooks.java
+++ b/src/main/java/org/pircbotx/hooks/CoreHooks.java
@@ -85,17 +85,7 @@ public class CoreHooks extends ListenerAdapter {
 				&& StringUtils.containsIgnoreCase(event.getMessage(), config.getNickservOnSuccess())) {
 			log.info("Successfully identified to nickserv");
 			Utils.setNickServIdentified(event.getBot());
-			//Hide the real host if enabled
-			if (config.isUserModeHideRealHost())
-				event.getBot().sendIRC().mode(event.getBot().getNick(),"+x");
 			if (config.isNickservDelayJoin()) {
-				if (config.getNickservDelayJoinTime() > 0)
-					try {
-						log.debug("Pausing for {} milliseconds before joining channels", config.getNickservDelayJoinTime());
-						Thread.sleep(config.getNickservDelayJoinTime());
-					} catch (InterruptedException e) {
-						throw new RuntimeException("Interrupted while pausing before joining channels", e);
-					}
 				for (Map.Entry<String, String> channelEntry : config.getAutoJoinChannels().entrySet())
 					event.getBot().sendIRC().joinChannel(channelEntry.getKey(), channelEntry.getValue());
 			}

--- a/src/main/java/org/pircbotx/hooks/CoreHooks.java
+++ b/src/main/java/org/pircbotx/hooks/CoreHooks.java
@@ -85,8 +85,17 @@ public class CoreHooks extends ListenerAdapter {
 				&& StringUtils.containsIgnoreCase(event.getMessage(), config.getNickservOnSuccess())) {
 			log.info("Successfully identified to nickserv");
 			Utils.setNickServIdentified(event.getBot());
-
+			//Hide the real host if enabled
+			if (config.isUserModeHideRealHost())
+				event.getBot().sendIRC().mode(event.getBot().getNick(),"+x");
 			if (config.isNickservDelayJoin()) {
+				if (config.getNickservDelayJoinTime() > 0)
+					try {
+						log.debug("Pausing for {} milliseconds before joining channels", config.getNickservDelayJoinTime());
+						Thread.sleep(config.getNickservDelayJoinTime());
+					} catch (InterruptedException e) {
+						throw new RuntimeException("Interrupted while pausing before joining channels", e);
+					}
 				for (Map.Entry<String, String> channelEntry : config.getAutoJoinChannels().entrySet())
 					event.getBot().sendIRC().joinChannel(channelEntry.getKey(), channelEntry.getValue());
 			}


### PR DESCRIPTION
Hey,

I've been a long time user of pircbotx and I would like to thank you for all the work so far. But after the release of 2.1 I was still missing some features I created workarounds for in my own bot. So I decided to try and fix that ;-)

So to the changes:
- added nickservCustomMessage: I use my bot on Quakenet and quakenet has no nickserv, they do have Q and you can auth to Q by sending a "PRIVMSG Q@CServe.quakenet.org :AUTH USER PASS" irc rawline. So I added the CustomMessage as an alternative to nickservPassword
- added userModeHideRealHost: sets mode +x after auth with nickserv, to hide your current hostname on irc. The reason I added it after the nickserv auth and before the channel join is because you need to be authed on Quakenet before using this command. And if it runs after joining the channel the bot parts/joins the channels again with the message (registered). Come to think of it, this might be usefull to use even when not authed to nickserv...
- added nickservDelayJoinTime: added so you can create a custom pause before joining the channels and after nickserv auth. This to make sure the userModeHideRealHost has run, or any other command you want to run before joining your channels

Anyway, I don't know if this will be usefull, you're of course free to do with it what you want. I'm open to feedback about my code/commit.

Greetings,

Cypher
