### PR TITLE
squid:S3052 - Fields should not be initialized to default values

### DIFF
--- a/src/main/java/org/pircbotx/Channel.java
+++ b/src/main/java/org/pircbotx/Channel.java
@@ -88,25 +88,25 @@ public class Channel implements Comparable<Channel> {
 	/**
 	 * Moderated (+m) status
 	 */
-	protected boolean moderated = false;
+	protected boolean moderated;
 	/**
 	 * No external messages (+n) status
 	 */
-	protected boolean noExternalMessages = false;
+	protected boolean noExternalMessages;
 	/**
 	 * Invite only (+i) status
 	 */
-	protected boolean inviteOnly = false;
+	protected boolean inviteOnly;
 	/**
 	 * Secret (+s) status
 	 */
-	protected boolean secret = false;
+	protected boolean secret;
 	/**
 	 * Private (+p) status
 	 */
-	protected boolean channelPrivate = false;
+	protected boolean channelPrivate;
 	@Getter(AccessLevel.NONE)
-	protected boolean topicProtection = false;
+	protected boolean topicProtection;
 	/**
 	 * Channel limit (+l #)
 	 */
@@ -114,10 +114,10 @@ public class Channel implements Comparable<Channel> {
 	/**
 	 * Channel key (+k)
 	 */
-	protected String channelKey = null;
+	protected String channelKey;
 	@Getter(AccessLevel.NONE)
 	@Setter(AccessLevel.NONE)
-	protected CountDownLatch modeChangeLatch = null;
+	protected CountDownLatch modeChangeLatch;
 	@Getter(AccessLevel.NONE)
 	protected final Object modeChangeLock = new Object();
 

--- a/src/main/java/org/pircbotx/Configuration.java
+++ b/src/main/java/org/pircbotx/Configuration.java
@@ -243,29 +243,28 @@ public class Configuration {
 	public static class Builder {
 		//WebIRC
 		/**
-		 * Enable or disable sending WEBIRC line on connect, default disabled
+		 * Enable or disable sending WEBIRC line on connect
 		 */
-		protected boolean webIrcEnabled = false;
+		protected boolean webIrcEnabled;
 		/**
-		 * Username of WEBIRC connection, must not be blank if WEBIRC is enabled
+		 * Username of WEBIRC connection
 		 */
-		protected String webIrcUsername = null;
+		protected String webIrcUsername;
 		/**
-		 * Hostname of WEBIRC connection, must not be blank if WEBIRC is enabled
+		 * Hostname of WEBIRC connection
 		 */
-		protected String webIrcHostname = null;
+		protected String webIrcHostname;
 		/**
-		 * IP address of WEBIRC connection, must be set if WEBIRC is enabled
+		 * IP address of WEBIRC connection
 		 */
-		protected InetAddress webIrcAddress = null;
+		protected InetAddress webIrcAddress;
 		/**
-		 * Password of WEBIRC connection, must not be blank if WEBIRC is enabled
+		 * Password of WEBIRC connection
 		 */
-		protected String webIrcPassword = null;
+		protected String webIrcPassword;
 		//Bot information
 		/**
-		 * The nick to be used for the IRC connection (nick!login@host), must
-		 * not be blank
+		 * The nick to be used for the IRC connection (nick!login@host)
 		 */
 		protected String name;
 		/**
@@ -312,25 +311,22 @@ public class Configuration {
 		protected boolean snapshotsEnabled = true;
 		//DCC
 		/**
-		 * If true sends filenames in quotes, otherwise uses underscores,
-		 * default enabled.
+		 * If true sends filenames in quotes, otherwise uses underscores
 		 */
-		protected boolean dccFilenameQuotes = false;
+		protected boolean dccFilenameQuotes;
 		/**
 		 * Ports to allow DCC incoming connections, recommended to set multiple
 		 * as DCC connections will be rejected if no free port can be found
 		 */
 		protected List<Integer> dccPorts = Lists.newArrayList();
 		/**
-		 * The local address to bind DCC connections to, defaults to null (which
-		 * will be figured out at runtime)
+		 * The local address to bind DCC connections to
 		 */
-		protected InetAddress dccLocalAddress = null;
+		protected InetAddress dccLocalAddress;
 		/**
-		 * The public address advertised to other users, defaults to null (which
-		 * will be figured out at runtime)
+		 * The public address advertised to other users
 		 */
-		protected InetAddress dccPublicAddress = null;
+		protected InetAddress dccPublicAddress;
 		/**
 		 * Timeout for user to accept a sent DCC request, defaults to {@link #getSocketTimeout()
 		 * }
@@ -347,27 +343,26 @@ public class Configuration {
 		protected int dccTransferBufferSize = 1024;
 		/**
 		 * Send DCC requests as passive/reverse requests if not specified
-		 * otherwise, default false
 		 */
-		protected boolean dccPassiveRequest = false;
+		protected boolean dccPassiveRequest;
 		//Connect information
 		/**
 		 * List of servers to connect to, easily add with the addServer methods
 		 */
 		protected List<ServerEntry> servers = Lists.newLinkedList();
 		/**
-		 * Password for IRC server, default null
+		 * Password for IRC server
 		 */
-		protected String serverPassword = null;
+		protected String serverPassword;
 		/**
 		 * Socket factory for connections, defaults to {@link SocketFactory#getDefault()
 		 * }
 		 */
 		protected SocketFactory socketFactory = SocketFactory.getDefault();
 		/**
-		 * Address to bind to when connecting to IRC server, default null
+		 * Address to bind to when connecting to IRC server
 		 */
-		protected InetAddress localAddress = null;
+		protected InetAddress localAddress;
 		/**
 		 * Charset encoding to use for connection, defaults to
 		 * {@link Charset#defaultCharset()}
@@ -396,10 +391,10 @@ public class Configuration {
 		protected boolean autoSplitMessage = true;
 		/**
 		 * Enable or disable automatic nick changing if a nick is in use by
-		 * adding a number to the end, default false which will throw a
+		 * adding a number to the end, will throw a
 		 * {@link IrcException} if the nick is already in use on the server
 		 */
-		protected boolean autoNickChange = false;
+		protected boolean autoNickChange;
 		/**
 		 * Millisecond delay between sending messages, default 1000 milliseconds
 		 */
@@ -419,18 +414,17 @@ public class Configuration {
 		 */
 		protected boolean onJoinWhoEnabled = true;
 		/**
-		 * Enable or disable use of an existing {@link IdentServer}, default
-		 * false. Note that the IdentServer must be started separately or else
+		 * Enable or disable use of an existing {@link IdentServer}
+		 * Note that the IdentServer must be started separately or else
 		 * an exception will be thrown
 		 *
 		 * @see IdentServer
 		 */
-		protected boolean identServerEnabled = false;
+		protected boolean identServerEnabled;
 		/**
-		 * Password to authenticate against NICKSERV, default null (will not try
-		 * to identify)
+		 * Password to authenticate against NICKSERV
 		 */
-		protected String nickservPassword = null;
+		protected String nickservPassword;
 		/**
 		 * Case-insensitive message a user with 
 		 * {@link #setNickservNick(java.lang.String) } in its hostmask will
@@ -457,28 +451,26 @@ public class Configuration {
 		/**
 		 * Some irc servers require a custom identify string.
 		 * eg: Quakenet: <code>PRIVMSG Q@CServe.quakenet.org :AUTH USER PASS</code>
-		 * default = null
 		 */
-		protected String nickservCustomMessage = null;
+		protected String nickservCustomMessage;
 		/**
-		 * Delay joining channels until were identified to nickserv, default
-		 * false
+		 * Delay joining channels until were identified to nickserv
 		 */
-		protected boolean nickservDelayJoin = false;
+		protected boolean nickservDelayJoin;
 		/**
-		 * Sets mode +x on the bot, to hide the real hostname, default = false
+		 * Sets mode +x on the bot, to hide the real hostname
 		 */
-		protected boolean userModeHideRealHost = false;
+		protected boolean userModeHideRealHost;
 		/**
-		 * Enable or disable automatic reconnecting, default false. Note that
+		 * Enable or disable automatic reconnecting. Note that
 		 * you MUST call {@link PircBotX#stopBotReconnect() } when you do not
 		 * want the bot to reconnect anymore!
 		 */
-		protected boolean autoReconnect = false;
+		protected boolean autoReconnect;
 		/**
-		 * Delay in milliseconds between reconnect attempts, default 0.
+		 * Delay in milliseconds between reconnect attempts.
 		 */
-		protected int autoReconnectDelay = 0;
+		protected int autoReconnectDelay;
 		/**
 		 * Number of times to attempt to reconnect, default 5.
 		 */
@@ -489,7 +481,7 @@ public class Configuration {
 		 * {@link ThreadedListenerManager}.
 		 */
 		//This is lazy loaded in {@link #getListenerManager()} since creating a thread pool is expensive
-		protected ListenerManager listenerManager = null;
+		protected ListenerManager listenerManager;
 		/**
 		 * Enable or disable CAP handling, defaults true.
 		 */

--- a/src/main/java/org/pircbotx/InputParser.java
+++ b/src/main/java/org/pircbotx/InputParser.java
@@ -264,7 +264,7 @@ public class InputParser implements Closeable {
 	protected final Configuration configuration;
 	protected final PircBotX bot;
 	protected final List<CapHandler> capHandlersFinished = Lists.newArrayList();
-	protected boolean capEndSent = false;
+	protected boolean capEndSent;
 	protected BufferedReader inputReader;
 	//Builders
 	/**
@@ -273,9 +273,9 @@ public class InputParser implements Closeable {
 	protected final Map<String, WhoisEvent.Builder> whoisBuilder = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
 	protected StringBuilder motdBuilder;
 	@Getter
-	protected boolean channelListRunning = false;
+	protected boolean channelListRunning;
 	protected ImmutableList.Builder<ChannelListEntry> channelListBuilder;
-	protected int nickSuffix = 0;
+	protected int nickSuffix;
 	protected final Multimap<Channel, BanListEvent.Entry> banListBuilder = LinkedListMultimap.create();
 
 	public InputParser(PircBotX bot) {

--- a/src/main/java/org/pircbotx/PircBotX.java
+++ b/src/main/java/org/pircbotx/PircBotX.java
@@ -122,9 +122,9 @@ public class PircBotX implements Comparable<PircBotX>, Closeable {
 	@Getter
 	protected List<String> enabledCapabilities = new ArrayList<String>();
 	protected String nick;
-	protected boolean loggedIn = false;
+	protected boolean loggedIn;
 	protected Thread shutdownHook;
-	protected volatile boolean reconnectStopped = false;
+	protected volatile boolean reconnectStopped;
 	protected ImmutableMap<String, String> reconnectChannels;
 	private State state = State.INIT;
 	protected final Object stateLock = new Object();
@@ -138,9 +138,9 @@ public class PircBotX implements Comparable<PircBotX>, Closeable {
 	 */
 	@Getter
 	@Setter(AccessLevel.PROTECTED)
-	protected boolean nickservIdentified = false;
-	private int connectAttempts = 0;
-	private int connectAttemptTotal = 0;
+	protected boolean nickservIdentified;
+	private int connectAttempts;
+	private int connectAttemptTotal;
 
 	/**
 	 * Constructs a PircBotX with the provided configuration.

--- a/src/main/java/org/pircbotx/ReplayServer.java
+++ b/src/main/java/org/pircbotx/ReplayServer.java
@@ -56,7 +56,7 @@ public class ReplayServer {
 	protected static class ReplayPircBotX extends PircBotX {
 		protected final Queue<String> outputQueue;
 		@Getter
-		protected boolean closed = false;
+		protected boolean closed;
 
 		public ReplayPircBotX(Configuration configuration, Queue<String> outputQueue) {
 			super(configuration);

--- a/src/main/java/org/pircbotx/User.java
+++ b/src/main/java/org/pircbotx/User.java
@@ -50,11 +50,11 @@ public class User extends UserHostmask {
 	/**
 	 * User's away status
 	 */
-	private String awayMessage = null;
+	private String awayMessage;
 	/**
 	 * Users IRCop status
 	 */
-	private boolean ircop = false;
+	private boolean ircop;
 	/**
 	 * The exact server that this user is joined to.
 	 *
@@ -64,7 +64,7 @@ public class User extends UserHostmask {
 	/**
 	 * The number of hops it takes to this user.
 	 */
-	private int hops = 0;
+	private int hops;
 
 	protected User(UserHostmask hostmask) {
 		super(hostmask);

--- a/src/main/java/org/pircbotx/UtilSSLSocketFactory.java
+++ b/src/main/java/org/pircbotx/UtilSSLSocketFactory.java
@@ -60,10 +60,10 @@ import lombok.extern.slf4j.Slf4j;
 public class UtilSSLSocketFactory extends SSLSocketFactory {
 	protected SSLSocketFactory wrappedFactory = (SSLSocketFactory) SSLSocketFactory.getDefault();
 	@Getter
-	protected boolean trustingAllCertificates = false;
+	protected boolean trustingAllCertificates;
 	@Getter
-	protected boolean diffieHellmanDisabled = false;
-	protected boolean wrappedFactoryChanged = false;
+	protected boolean diffieHellmanDisabled;
+	protected boolean wrappedFactoryChanged;
 
 	/**
 	 * By default, trust ALL certificates. <b>This is <i>very</i> insecure.</b>

--- a/src/main/java/org/pircbotx/dcc/DccHandler.java
+++ b/src/main/java/org/pircbotx/dcc/DccHandler.java
@@ -68,7 +68,7 @@ public class DccHandler implements Closeable {
 	protected final List<PendingSendFileTransfer> pendingSendTransfers = new ArrayList<PendingSendFileTransfer>();
 	protected final Map<PendingSendFileTransferPassive, CountDownLatch> pendingSendPassiveTransfers = new HashMap<PendingSendFileTransferPassive, CountDownLatch>();
 	protected final Map<PendingSendChatPassive, CountDownLatch> pendingSendPassiveChat = new HashMap<PendingSendChatPassive, CountDownLatch>();
-	protected boolean shuttingDown = false;
+	protected boolean shuttingDown;
 
 	public boolean processDcc(UserHostmask userHostmask, final User user, String request) throws IOException {
 		List<String> requestParts = tokenizeDccRequest(request);
@@ -656,7 +656,7 @@ public class DccHandler implements Closeable {
 		protected final User user;
 		protected final String filename;
 		protected final int port;
-		protected long position = 0;
+		protected long position;
 	}
 
 	@Data
@@ -664,7 +664,7 @@ public class DccHandler implements Closeable {
 		protected final User user;
 		protected final String filename;
 		protected final String transferToken;
-		protected long startPosition = 0;
+		protected long startPosition;
 		protected InetAddress receiverAddress;
 		protected int receiverPort;
 	}

--- a/src/main/java/org/pircbotx/output/OutputRaw.java
+++ b/src/main/java/org/pircbotx/output/OutputRaw.java
@@ -46,7 +46,7 @@ public class OutputRaw {
 	protected final ReentrantLock writeLock = new ReentrantLock(true);
 	protected final Condition writeNowCondition = writeLock.newCondition();
 	protected final long delayNanos;
-	protected long lastSentLine = 0;
+	protected long lastSentLine;
 
 	public OutputRaw(PircBotX bot) {
 		this.bot = bot;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S3052 - Fields should not be initialized to default values

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S3052

Please let me know if you have any questions.

M-Ezzat
