### PR TITLE
Pass more data to UnknownEvents so consumers have more options

### DIFF
--- a/src/main/java/org/pircbotx/InputParser.java
+++ b/src/main/java/org/pircbotx/InputParser.java
@@ -31,7 +31,6 @@ import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -339,7 +338,7 @@ public class InputParser implements Closeable {
 		//Make sure this is a valid IRC line
 		if (!sourceRaw.startsWith(":")) {
 			// We don't know what this line means.
-			configuration.getListenerManager().onEvent(new UnknownEvent(bot, line));
+			configuration.getListenerManager().onEvent(new UnknownEvent(bot, target, "", command, line, parsedLine, tags.build()));
 			if (!bot.loggedIn)
 				//Pass to CapHandlers, could be important
 				for (CapHandler curCapHandler : configuration.getCapHandlers())
@@ -520,10 +519,10 @@ public class InputParser implements Closeable {
 				boolean success = bot.getDccHandler().processDcc(source, sourceUser, request);
 				if (!success)
 					// The DccManager didn't know what to do with the line.
-					configuration.getListenerManager().onEvent(new UnknownEvent(bot, line));
+					configuration.getListenerManager().onEvent(new UnknownEvent(bot, target, source.getNick(), command, line, parsedLine, tags));
 			} else
 				// An unknown CTCP message - ignore it.
-				configuration.getListenerManager().onEvent(new UnknownEvent(bot, line));
+				configuration.getListenerManager().onEvent(new UnknownEvent(bot, target, source.getNick(), command, line, parsedLine, tags));
 		} else if (command.equals("PRIVMSG") && channel != null) {
 			// This is a normal message to a channel.
 			sourceUser = createUserIfNull(sourceUser, source);
@@ -643,7 +642,7 @@ public class InputParser implements Closeable {
 		else
 			// If we reach this point, then we've found something that the PircBotX
 			// Doesn't currently deal with.
-			configuration.getListenerManager().onEvent(new UnknownEvent(bot, line));
+			configuration.getListenerManager().onEvent(new UnknownEvent(bot, target, source.getNick(), command, line, parsedLine, tags));
 	}
 
 	/**

--- a/src/main/java/org/pircbotx/hooks/events/UnknownEvent.java
+++ b/src/main/java/org/pircbotx/hooks/events/UnknownEvent.java
@@ -19,12 +19,16 @@ package org.pircbotx.hooks.events;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableMap;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import org.pircbotx.hooks.Event;
 import org.pircbotx.PircBotX;
+
+import java.util.List;
 
 /**
  * This event is dispatched whenever we receive a line from the server that
@@ -36,13 +40,51 @@ import org.pircbotx.PircBotX;
 @EqualsAndHashCode(callSuper = true)
 public class UnknownEvent extends Event {
 	/**
+	 * The target of the event
+	 */
+	@Getter(onMethod = @_(
+			@Override))
+	protected final String target;
+	/**
+	 * The nickname (if any) of the originating user
+	 */
+	@Getter(onMethod = @_(
+			@Override))
+	protected final String nick;
+	/**
+	 * The IRC command that was issued
+	 */
+	@Getter(onMethod = @_(
+			@Override))
+	protected final String command;
+	/**
 	 * The raw line that was received from the server.
 	 */
+	@Getter(onMethod = @_(
+			@Override))
 	protected final String line;
+	/**
+	 * The parsed line
+	 */
+	@Getter(onMethod = @_(
+			@Override))
+	protected final List<String> parsedLine;
+	/**
+	 * The IRCv3 tags (if any)
+	 */
+	@Getter(onMethod = @_(
+			@Override))
+	protected final ImmutableMap<String, String> tags;
 
-	public UnknownEvent(PircBotX bot, @NonNull String line) {
+
+	public UnknownEvent(PircBotX bot, String target, String nick, String command, @NonNull String line, List<String> parsedLine, ImmutableMap<String, String> tags) {
 		super(bot);
+		this.target = target;
+		this.nick = nick;
+		this.command = command;
 		this.line = line;
+		this.parsedLine = parsedLine;
+		this.tags = tags;
 	}
 
 	/**

--- a/src/main/java/org/pircbotx/hooks/events/UnknownEvent.java
+++ b/src/main/java/org/pircbotx/hooks/events/UnknownEvent.java
@@ -42,38 +42,32 @@ public class UnknownEvent extends Event {
 	/**
 	 * The target of the event
 	 */
-	@Getter(onMethod = @_(
-			@Override))
+	@Getter
 	protected final String target;
 	/**
 	 * The nickname (if any) of the originating user
 	 */
-	@Getter(onMethod = @_(
-			@Override))
+	@Getter
 	protected final String nick;
 	/**
 	 * The IRC command that was issued
 	 */
-	@Getter(onMethod = @_(
-			@Override))
+	@Getter
 	protected final String command;
 	/**
 	 * The raw line that was received from the server.
 	 */
-	@Getter(onMethod = @_(
-			@Override))
+	@Getter
 	protected final String line;
 	/**
 	 * The parsed line
 	 */
-	@Getter(onMethod = @_(
-			@Override))
+	@Getter
 	protected final List<String> parsedLine;
 	/**
 	 * The IRCv3 tags (if any)
 	 */
-	@Getter(onMethod = @_(
-			@Override))
+	@Getter
 	protected final ImmutableMap<String, String> tags;
 
 


### PR DESCRIPTION
My primary goal here was to have a way to handle new events by command type without having to wait for full library support. Specifically, [twitch added a USERNOTICE command](https://discuss.dev.twitch.tv/t/important-re-subscription-change/6463)

Instead of implementing a twitch-specific event, I thought it made more sense to just pass additional data to the UnknownEvent, so individual applications can handle them as needed.
