### PR TITLE
Fix for Issue #299 - Generify getV3Tags()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target/
+/.idea/
+pircbotx.iml

--- a/src/main/java/org/pircbotx/InputParser.java
+++ b/src/main/java/org/pircbotx/InputParser.java
@@ -505,7 +505,7 @@ public class InputParser implements Closeable {
 				configuration.getListenerManager().onEvent(new VersionEvent(bot, source, sourceUser, channel));
 			else if (request.startsWith("ACTION "))
 				// ACTION request
-				configuration.getListenerManager().onEvent(new ActionEvent(bot, source, sourceUser, channel, target, request.substring(7)));
+				configuration.getListenerManager().onEvent(new ActionEvent(bot, source, sourceUser, channel, target, request.substring(7), tags));
 			else if (request.startsWith("PING "))
 				// PING request
 				configuration.getListenerManager().onEvent(new PingEvent(bot, source, sourceUser, channel, request.substring(5)));
@@ -533,7 +533,7 @@ public class InputParser implements Closeable {
 			//Add to private message
 			sourceUser = createUserIfNull(sourceUser, source);
 			bot.getUserChannelDao().addUserToPrivate(sourceUser);
-			configuration.getListenerManager().onEvent(new PrivateMessageEvent(bot, source, sourceUser, message));
+			configuration.getListenerManager().onEvent(new PrivateMessageEvent(bot, source, sourceUser, message, tags));
 		} else if (command.equals("JOIN")) {
 			// Someone is joining a channel.
 			if (source.getNick().equalsIgnoreCase(bot.getNick())) {
@@ -581,7 +581,7 @@ public class InputParser implements Closeable {
 			configuration.getListenerManager().onEvent(new NickChangeEvent(bot, source.getNick(), newNick, source, sourceUser));
 		} else if (command.equals("NOTICE")) {
 			// Someone is sending a notice.
-			configuration.getListenerManager().onEvent(new NoticeEvent(bot, source, sourceUser, channel, target, message));
+			configuration.getListenerManager().onEvent(new NoticeEvent(bot, source, sourceUser, channel, target, message, tags));
 		} else if (command.equals("QUIT")) {
 			UserChannelDaoSnapshot daoSnapshot;
 			UserSnapshot sourceSnapshot;

--- a/src/main/java/org/pircbotx/hooks/events/ActionEvent.java
+++ b/src/main/java/org/pircbotx/hooks/events/ActionEvent.java
@@ -18,6 +18,8 @@
 package org.pircbotx.hooks.events;
 
 import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableMap;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -69,14 +71,19 @@ public class ActionEvent extends Event implements GenericMessageEvent, GenericCh
 	 * The action message.
 	 */
 	protected final String action;
+	/**
+	 * The IrcV3 tags
+	 */
+	protected final ImmutableMap<String, String> tags;
 
-	public ActionEvent(PircBotX bot, @NonNull UserHostmask userHostmask, User user, Channel channel, @NonNull String channelSource, @NonNull String action) {
+	public ActionEvent(PircBotX bot, @NonNull UserHostmask userHostmask, User user, Channel channel, @NonNull String channelSource, @NonNull String action, ImmutableMap<String, String> tags) {
 		super(bot);
 		this.userHostmask = userHostmask;
 		this.user = user;
 		this.channel = channel;
 		this.channelSource = channelSource;
 		this.action = action;
+		this.tags = tags;
 	}
 
 	/**
@@ -133,5 +140,12 @@ public class ActionEvent extends Event implements GenericMessageEvent, GenericCh
 	@Override
 	public void respondPrivateMessage(String response) {
 		getUser().send().message(response);
+	}
+
+	/**
+	 * Alias of {@link #getTags() }
+	 */
+	public ImmutableMap<String, String> getV3Tags() {
+		return tags;
 	}
 }

--- a/src/main/java/org/pircbotx/hooks/events/NoticeEvent.java
+++ b/src/main/java/org/pircbotx/hooks/events/NoticeEvent.java
@@ -18,6 +18,8 @@
 package org.pircbotx.hooks.events;
 
 import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableMap;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -67,14 +69,19 @@ public class NoticeEvent extends Event implements GenericMessageEvent, GenericCh
 	 * The notice message.
 	 */
 	protected final String notice;
+	/**
+	 * The IrcV3 tags
+	 */
+	protected final ImmutableMap<String, String> tags;
 
-	public NoticeEvent(PircBotX bot, @NonNull UserHostmask userHostmask, User user, Channel channel, @NonNull String channelSource, @NonNull String notice) {
+	public NoticeEvent(PircBotX bot, @NonNull UserHostmask userHostmask, User user, Channel channel, @NonNull String channelSource, @NonNull String notice, ImmutableMap<String, String> tags) {
 		super(bot);
 		this.user = user;
 		this.userHostmask = userHostmask;
 		this.channel = channel;
 		this.channelSource = channelSource;
 		this.notice = notice;
+		this.tags = tags;
 	}
 
 	/**
@@ -124,5 +131,12 @@ public class NoticeEvent extends Event implements GenericMessageEvent, GenericCh
 	 */
 	public void respondPrivateMessage(String response) {
 		getUser().send().message(response);
+	}
+
+	/**
+	 * Alias of {@link #getTags() }
+	 */
+	public ImmutableMap<String, String> getV3Tags() {
+		return tags;
 	}
 }

--- a/src/main/java/org/pircbotx/hooks/events/PrivateMessageEvent.java
+++ b/src/main/java/org/pircbotx/hooks/events/PrivateMessageEvent.java
@@ -18,6 +18,9 @@
 package org.pircbotx.hooks.events;
 
 import javax.annotation.Nullable;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import org.pircbotx.User;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -55,12 +58,17 @@ public class PrivateMessageEvent extends Event implements GenericMessageEvent {
 	@Getter(onMethod = @_(
 			@Override))
 	protected final String message;
+	/**
+	 * The IrcV3 tags
+	 */
+	protected final ImmutableMap<String, String> tags;
 
-	public PrivateMessageEvent(PircBotX bot, @NonNull UserHostmask userHostmask, User user, @NonNull String message) {
+	public PrivateMessageEvent(PircBotX bot, @NonNull UserHostmask userHostmask, User user, @NonNull String message, ImmutableMap<String, String> tags) {
 		super(bot);
 		this.userHostmask = userHostmask;
 		this.user = user;
 		this.message = message;
+		this.tags = tags;
 	}
 
 	/**
@@ -81,5 +89,12 @@ public class PrivateMessageEvent extends Event implements GenericMessageEvent {
 	@Override
 	public void respondPrivateMessage(String message) {
 		respond(message);
+	}
+
+	/**
+	 * Alias of {@link #getTags() }
+	 */
+	public ImmutableMap<String, String> getV3Tags() {
+		return tags;
 	}
 }

--- a/src/main/java/org/pircbotx/hooks/types/GenericMessageEvent.java
+++ b/src/main/java/org/pircbotx/hooks/types/GenericMessageEvent.java
@@ -17,6 +17,7 @@
  */
 package org.pircbotx.hooks.types;
 
+import com.google.common.collect.ImmutableMap;
 import org.pircbotx.hooks.events.MessageEvent;
 import org.pircbotx.hooks.events.PrivateMessageEvent;
 
@@ -47,4 +48,9 @@ public interface GenericMessageEvent extends GenericUserEvent {
 	 * Like {@link #respond(String)}, without the Username: prefix
 	 */
 	public void respondWith(String fullLine);
+
+	/**
+	 * Accessor for the IRCv3 Message tags
+	 */
+	public ImmutableMap<String, String> getV3Tags();
 }


### PR DESCRIPTION
Fairly straightforward addition of support for IRCv3 tags to all GenericMessageEvents, including MessageEvent (where it originated) and ActionEvent (which commonly possesses events as well).

No additional parsing of IRC tags is being done; the parsing happens anyway, and is discarded for most events except for MessageEvent. This change simply includes the otherwise-discarded tags with more Events.

Overall, a fairly simple fix. It's taken me longer to set up this pull request than it did for me to fix the code.
