### PR TITLE
Add field to check if user has a secure connection when performing a whois

### DIFF
--- a/src/main/java/org/pircbotx/InputParser.java
+++ b/src/main/java/org/pircbotx/InputParser.java
@@ -868,6 +868,10 @@ public class InputParser implements Closeable {
 					.exists(false)
 					.generateEvent(bot);
 			configuration.getListenerManager().onEvent(event);
+		} else if (code == RPL_WHOIS_SECURE) {
+			//If present, tells us that the user is using a secure connection
+			//671 TheLQ TheLQ-PircBotX :is using a secure connection
+			whoisBuilder.get(parsedResponse.get(1)).secureConnection(true);
 		} else if (code == RPL_ENDOFWHOIS) {
 			//End of whois
 			//318 TheLQ Plazma :End of /WHOIS list.

--- a/src/main/java/org/pircbotx/ReplyConstants.java
+++ b/src/main/java/org/pircbotx/ReplyConstants.java
@@ -151,6 +151,7 @@ public final class ReplyConstants {
 	public static final int RPL_USERS = 393;
 	public static final int RPL_ENDOFUSERS = 394;
 	public static final int RPL_NOUSERS = 395;
+	public static final int RPL_WHOIS_SECURE = 671;
 	// Reserved Numerics.
 	public static final int RPL_TRACECLASS = 209;
 	public static final int RPL_STATSQLINE = 217;

--- a/src/main/java/org/pircbotx/hooks/events/WhoisEvent.java
+++ b/src/main/java/org/pircbotx/hooks/events/WhoisEvent.java
@@ -61,6 +61,7 @@ public class WhoisEvent extends Event {
 	protected final String registeredAs;
 	protected final boolean exists;
 	protected final String awayMessage;
+	protected final boolean secureConnection;
 
 	WhoisEvent(PircBotX bot, @NonNull Builder builder) {
 		super(bot);
@@ -76,6 +77,7 @@ public class WhoisEvent extends Event {
 		this.registeredAs = builder.registeredAs;
 		this.exists = builder.exists;
 		this.awayMessage = builder.awayMessage;
+		this.secureConnection = builder.secureConnection;
 	}
 
 	public static Builder builder() {

--- a/src/test/java/org/pircbotx/InputParserTest.java
+++ b/src/test/java/org/pircbotx/InputParserTest.java
@@ -939,6 +939,7 @@ public class InputParserTest {
 		assertEquals(event.getSignOnTime(), 1347373349, "Sign on time doesn't match given");
 		assertNull(event.getRegisteredAs(), "User isn't registered");
 		assertTrue(event.isExists(), "User should exist");
+		assertFalse(event.isSecureConnection(), "User should have insecure connection");
 
 		//Verify channels
 		assertTrue(event.getChannels().contains("+#aChannel"), "Doesn't contain first given voice channel");
@@ -1023,6 +1024,17 @@ public class InputParserTest {
 		WhoisEvent event = bot.getTestEvent(WhoisEvent.class, "WhoisEvent not dispatched");
 		assertNotNull(event.getChannels(), "WhoisEvent.channels is null");
 		assertTrue(event.getChannels().isEmpty(), "Unknown channels " + event.getChannels());
+	}
+
+	@Test
+	public void whoisSecureConnectionTest() throws IOException, IrcException {
+		inputParser.handleLine(":irc.someserver.net 311 PircBotXUser OtherUser ~OtherLogin some.host1 * :" + aString);
+		inputParser.handleLine(":irc.someserver.net 671 PircBotXUser OtherUser :is using a secure connection");
+		inputParser.handleLine(":irc.someserver.net 318 PircBotXUser otheruser :End of /WHOIS list.");
+
+		//Make sure we get the correct event
+		WhoisEvent event = bot.getTestEvent(WhoisEvent.class, "WhoisEvent not dispatched");
+		assertTrue(event.isSecureConnection(), "Event used insecure connection");
 	}
 
 	@Test


### PR DESCRIPTION
I noticed that a whois event currently can't tell if someone is using a secure connection or not. I've added this is so you can query it on the `WhoisEvent`