### PR TITLE
UnknownEvent add respondWith method

### DIFF
--- a/src/main/java/org/pircbotx/hooks/events/UnknownEvent.java
+++ b/src/main/java/org/pircbotx/hooks/events/UnknownEvent.java
@@ -89,4 +89,8 @@ public class UnknownEvent extends Event {
 	public void respond(String response) {
 		getBot().sendRaw().rawLine(response);
 	}
+	
+	public void respondWith(String response) {
+        	getBot().send().message(target, response);
+    	}
 }

--- a/src/main/java/org/pircbotx/hooks/events/UnknownEvent.java
+++ b/src/main/java/org/pircbotx/hooks/events/UnknownEvent.java
@@ -90,7 +90,7 @@ public class UnknownEvent extends Event {
 		getBot().sendRaw().rawLine(response);
 	}
 	
-	public void respondWith(String response) {
-        	getBot().send().message(target, response);
+	public void respondWith(String fullLine) {
+        	getBot().send().message(target, fullLine);
     	}
 }

--- a/src/main/java/org/pircbotx/hooks/events/UnknownEvent.java
+++ b/src/main/java/org/pircbotx/hooks/events/UnknownEvent.java
@@ -91,6 +91,6 @@ public class UnknownEvent extends Event {
 	}
 	
 	public void respondWith(String fullLine) {
-        	getBot().send().message(target, fullLine);
+        	getBot().sendIRC().message(target, fullLine);
     	}
 }


### PR DESCRIPTION
With the pull request #318 a user added more functionality for the UnkownEvent. As for other events it would be nice if the UnkownEvent has a respondWith method implemented.

The implementation of the method is exactly the same as for the [MessageEvent](https://github.com/pircbotx/pircbotx/blob/65456d756ae57cc165ab1b77326333e15bf83380/src/main/java/org/pircbotx/hooks/events/MessageEvent.java#L120).