### PR TITLE
Sending password to server without local logging password

### DIFF
--- a/src/main/java/org/pircbotx/PircBotX.java
+++ b/src/main/java/org/pircbotx/PircBotX.java
@@ -330,7 +330,7 @@ public class PircBotX implements Comparable<PircBotX>, Closeable {
 					+ " " + configuration.getWebIrcHostname()
 					+ " " + configuration.getWebIrcAddress().getHostAddress());
 		if (StringUtils.isNotBlank(configuration.getServerPassword()))
-			sendRaw().rawLineNow("PASS " + configuration.getServerPassword());
+			sendRaw().sendPass(configuration.getServerPassword());
 
 		sendRaw().rawLineNow("NICK " + configuration.getName());
 		sendRaw().rawLineNow("USER " + configuration.getLogin() + " 8 * :" + configuration.getRealName());

--- a/src/main/java/org/pircbotx/output/OutputRaw.java
+++ b/src/main/java/org/pircbotx/output/OutputRaw.java
@@ -123,6 +123,24 @@ public class OutputRaw {
 			writeLock.unlock();
 		}
 	}
+	
+	public void sendPass(String password){
+		checkNotNull(password, "Line cannot be null");
+		checkArgument(bot.isConnected(), "Not connected to server");
+		writeLock.lock();
+		try {
+			log.info(OUTPUT_MARKER, "PASS ****************");
+			Utils.sendRawLineToServer(bot, "PASS " + password);
+			lastSentLine = System.nanoTime();
+			writeNowCondition.signalAll();
+		} catch (IOException e) {
+			throw new RuntimeException("IO exception when sending line to server, is the network still up? " + exceptionDebug(), e);
+		} catch (Exception e) {
+			throw new RuntimeException("Could not send line to server. " + exceptionDebug(), e);
+		} finally {
+			writeLock.unlock();
+		}
+	}
 
 	public void rawLineSplit(String prefix, String message) {
 		rawLineSplit(prefix, message, "");

--- a/src/main/java/org/pircbotx/output/OutputRaw.java
+++ b/src/main/java/org/pircbotx/output/OutputRaw.java
@@ -124,6 +124,11 @@ public class OutputRaw {
 		}
 	}
 	
+	/**
+	 * Sends password to server without logging password
+	 * <p>
+	 * @param password String contains password
+	 */
 	public void sendPass(String password){
 		checkNotNull(password, "Line cannot be null");
 		checkArgument(bot.isConnected(), "Not connected to server");


### PR DESCRIPTION
I think it will be more securely. Then password is sended to server logger says "PASS **********" instead of "PASS your_secret_password"