### PR TITLE
 BugFix: DCC RESUME & Enhancement: Faster DCC SEND

### DIFF
--- a/src/main/java/org/pircbotx/Configuration.java
+++ b/src/main/java/org/pircbotx/Configuration.java
@@ -95,7 +95,7 @@ public class Configuration {
 	protected final InetAddress dccPublicAddress;
 	protected final int dccAcceptTimeout;
 	protected final int dccResumeAcceptTimeout;
-	protected final int dccTransferBufferSize;
+	protected final int dccReceiveTransferBufferSize;
 	protected final boolean dccPassiveRequest;
 	//Connect information
 	protected final ImmutableList<ServerEntry> servers;
@@ -154,7 +154,7 @@ public class Configuration {
 		checkNotNull(builder.getDccPorts(), "DCC ports list cannot be null");
 		checkArgument(builder.getDccAcceptTimeout() > 0, "dccAcceptTimeout must be positive");
 		checkArgument(builder.getDccResumeAcceptTimeout() > 0, "dccResumeAcceptTimeout must be positive");
-		checkArgument(builder.getDccTransferBufferSize() > 0, "dccTransferBufferSize must be positive");
+		checkArgument(builder.getDccReceiveTransferBufferSize() > 0, "dccReceiveTransferBufferSize must be positive");
 		checkNotNull(builder.getServers(), "Servers list cannot be null");
 		checkArgument(!builder.getServers().isEmpty(), "Must specify servers to connect to");
 		for (ServerEntry serverEntry : builder.getServers()) {
@@ -204,7 +204,7 @@ public class Configuration {
 		this.dccPublicAddress = builder.getDccPublicAddress();
 		this.dccAcceptTimeout = builder.getDccAcceptTimeout();
 		this.dccResumeAcceptTimeout = builder.getDccResumeAcceptTimeout();
-		this.dccTransferBufferSize = builder.getDccTransferBufferSize();
+		this.dccReceiveTransferBufferSize = builder.getDccReceiveTransferBufferSize();
 		this.dccPassiveRequest = builder.isDccPassiveRequest();
 		this.servers = ImmutableList.copyOf(builder.getServers());
 		this.serverPassword = builder.getServerPassword();
@@ -353,9 +353,9 @@ public class Configuration {
 		 */
 		protected int dccResumeAcceptTimeout = -1;
 		/**
-		 * Size of the DCC file transfer buffer, default 1024 bytes
+		 * Size of the DCC Receive file transfer buffer, default 1024 bytes
 		 */
-		protected int dccTransferBufferSize = 1024;
+		protected int dccReceiveTransferBufferSize = 1024;
 		/**
 		 * Send DCC requests as passive/reverse requests if not specified
 		 * otherwise, default false
@@ -560,7 +560,7 @@ public class Configuration {
 			this.dccPublicAddress = configuration.getDccPublicAddress();
 			this.dccAcceptTimeout = configuration.getDccAcceptTimeout();
 			this.dccResumeAcceptTimeout = configuration.getDccResumeAcceptTimeout();
-			this.dccTransferBufferSize = configuration.getDccTransferBufferSize();
+			this.dccReceiveTransferBufferSize = configuration.getDccReceiveTransferBufferSize();
 			this.dccPassiveRequest = configuration.isDccPassiveRequest();
 			this.servers.clear();
 			this.servers.addAll(configuration.getServers());
@@ -624,7 +624,7 @@ public class Configuration {
 			this.dccPublicAddress = otherBuilder.getDccPublicAddress();
 			this.dccAcceptTimeout = otherBuilder.getDccAcceptTimeout();
 			this.dccResumeAcceptTimeout = otherBuilder.getDccResumeAcceptTimeout();
-			this.dccTransferBufferSize = otherBuilder.getDccTransferBufferSize();
+			this.dccReceiveTransferBufferSize = otherBuilder.getDccReceiveTransferBufferSize();
 			this.dccPassiveRequest = otherBuilder.isDccPassiveRequest();
 			this.servers.clear();
 			this.servers.addAll(otherBuilder.getServers());

--- a/src/main/java/org/pircbotx/dcc/DccHandler.java
+++ b/src/main/java/org/pircbotx/dcc/DccHandler.java
@@ -131,6 +131,8 @@ public class DccHandler implements Closeable {
 							transfer.setStartPosition(position);
 							log.debug("Passive send file transfer of file {} to user {} set to position {}",
 									transfer.getFilename(), transfer.getUser().getNick(), position);
+							bot.sendDCC().filePassiveResumeAccept(transfer.getUser().getNick(), transfer.getFilename(),
+									transfer.getStartPosition(), transfer.getTransferToken());
 							return true;
 						}
 					}
@@ -145,6 +147,8 @@ public class DccHandler implements Closeable {
 							transfer.setPosition(position);
 							log.debug("Send file transfer of file {} to user {} set to position {}",
 									transfer.getFilename(), transfer.getUser().getNick(), position);
+							bot.sendDCC().fileResumeAccept(transfer.getUser().getNick(), transfer.getFilename(),
+									transfer.getPort(), transfer.getPosition());
 							return true;
 						}
 					}

--- a/src/main/java/org/pircbotx/dcc/DccHandler.java
+++ b/src/main/java/org/pircbotx/dcc/DccHandler.java
@@ -114,7 +114,7 @@ public class DccHandler implements Closeable {
 			//Someone is trying to resume sending a file to us
 			//Example: DCC RESUME <filename> 0 <position> <token>
 			//Reply with: DCC ACCEPT <filename> 0 <position> <token>
-			String filename = requestParts.get(2);
+			String filename = requestParts.get(2).replaceAll("\"", "");
 			int port = Integer.parseInt(requestParts.get(3));
 			long position = Long.parseLong(requestParts.get(4));
 

--- a/src/main/java/org/pircbotx/dcc/DccHandler.java
+++ b/src/main/java/org/pircbotx/dcc/DccHandler.java
@@ -114,7 +114,7 @@ public class DccHandler implements Closeable {
 			//Someone is trying to resume sending a file to us
 			//Example: DCC RESUME <filename> 0 <position> <token>
 			//Reply with: DCC ACCEPT <filename> 0 <position> <token>
-			String filename = requestParts.get(2);
+			String filename = requestParts.get(2).replaceAll("\"", "");;
 			int port = Integer.parseInt(requestParts.get(3));
 			long position = Long.parseLong(requestParts.get(4));
 

--- a/src/main/java/org/pircbotx/dcc/ReceiveFileTransfer.java
+++ b/src/main/java/org/pircbotx/dcc/ReceiveFileTransfer.java
@@ -49,7 +49,7 @@ public class ReceiveFileTransfer extends FileTransfer {
 		fileOutput.seek(startPosition);
 
 		//Recieve file
-		int defaultBufferSize = configuration.getDccTransferBufferSize();
+		int defaultBufferSize = configuration.getDccReceiveTransferBufferSize();
 		byte[] inBuffer = new byte[defaultBufferSize];
 		byte[] outBuffer = new byte[4];
 		while (true) {

--- a/src/main/java/org/pircbotx/dcc/SendFileTransfer.java
+++ b/src/main/java/org/pircbotx/dcc/SendFileTransfer.java
@@ -46,9 +46,9 @@ public class SendFileTransfer extends FileTransfer {
 			// https://stackoverflow.com/questions/7379469/filechannel-transferto-for-large-file-in-windows/20916464
 			long bufferSize = (64 * 1024 * 1024) - (32 * 1024);
 			long size = inChannel.size();
-			long position = startPosition;
-			while (position < size) {
-				position += inChannel.transferTo(position, bufferSize, outChannel);
+			this.bytesTransfered = this.startPosition;
+			while (this.bytesTransfered < size) {
+				this.bytesTransfered += inChannel.transferTo(this.bytesTransfered, bufferSize, outChannel);
 			}
 		}
 	}

--- a/src/main/java/org/pircbotx/dcc/SendFileTransfer.java
+++ b/src/main/java/org/pircbotx/dcc/SendFileTransfer.java
@@ -17,13 +17,13 @@
  */
 package org.pircbotx.dcc;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.Socket;
-import lombok.Cleanup;
+import java.nio.channels.FileChannel;
+import java.nio.channels.SocketChannel;
+
 import org.pircbotx.Configuration;
 import org.pircbotx.User;
 
@@ -39,29 +39,17 @@ public class SendFileTransfer extends FileTransfer {
 
 	@Override
 	protected void transferFile() throws IOException {
-		@Cleanup
-		BufferedOutputStream socketOutput = new BufferedOutputStream(socket.getOutputStream());
-		@Cleanup
-		BufferedInputStream socketInput = new BufferedInputStream(socket.getInputStream());
-		@Cleanup
-		BufferedInputStream fileInput = new BufferedInputStream(new FileInputStream(file));
-
-		// Check for resuming.
-		if (startPosition > 0) {
-			long bytesSkipped = 0;
-			while (bytesSkipped < startPosition)
-				bytesSkipped += fileInput.skip(startPosition - bytesSkipped);
-		}
-
-		byte[] outBuffer = new byte[configuration.getDccTransferBufferSize()];
-		byte[] inBuffer = new byte[4];
-		int bytesRead;
-		while ((bytesRead = fileInput.read(outBuffer, 0, outBuffer.length)) != -1) {
-			socketOutput.write(outBuffer, 0, bytesRead);
-			socketOutput.flush();
-			socketInput.read(inBuffer, 0, inBuffer.length);
-			bytesTransfered += bytesRead;
-			onAfterSend();
+		try (FileInputStream inputStream = new FileInputStream(file);) {
+			FileChannel inChannel = inputStream.getChannel();
+			SocketChannel outChannel = socket.getChannel();
+			// Windows optimized buffer size.  It seems to help
+			// https://stackoverflow.com/questions/7379469/filechannel-transferto-for-large-file-in-windows/20916464
+			long bufferSize = (64 * 1024 * 1024) - (32 * 1024);
+			long size = inChannel.size();
+			long position = startPosition;
+			while (position < size) {
+				position += inChannel.transferTo(position, bufferSize, outChannel);
+			}
 		}
 	}
 }


### PR DESCRIPTION
I tested both of these changes on mIRC and HexChat with success.

**BugFix: DCC RESUME**
PircbotX did not send DCC ACCEPT after modifying the file position.
The client would wait indefinitely after requesting DCC RESUME.

mIRC sends filename wrapped in double quotes on resume that caused the transfer file name to not match and not resume.  Removed double quotes from incoming file name.

**Enhancement: Faster DCC SEND**

Converted DccHandler to create ServerSockets using ServerSocketChannel
Converted SendFileTransfer to transfer files with java.nio.channels
Changed the dccTransferBufferSize to dccReceiveTransferBufferSize
java.nio.channels.FileTransfer.transferTo can break with very high values so this is better protected.
Changed buffer size used to 64Mb-32Kb which is efficient for windows.

I'm getting my full 200mbit connection on a single transfer with this method.
Previous transfer method gave me around 4Kb/s

