### PR TITLE
Add IRCv3 tags to other events

### DIFF
--- a/src/main/java/org/pircbotx/hooks/events/JoinEvent.java
+++ b/src/main/java/org/pircbotx/hooks/events/JoinEvent.java
@@ -17,6 +17,7 @@
  */
 package org.pircbotx.hooks.events;
 
+import com.google.common.collect.ImmutableMap;
 import javax.annotation.Nullable;
 import org.pircbotx.Channel;
 import org.pircbotx.User;
@@ -57,12 +58,17 @@ public class JoinEvent extends Event implements GenericChannelUserEvent {
 	@Getter(onMethod = @__({
 			@Override}))
 	protected final UserHostmask userHostmask;
+	/**
+	 * The IrcV3 tags
+	 */
+	protected final ImmutableMap<String, String> tags;
 
-	public JoinEvent(PircBotX bot, @NonNull Channel channel, @NonNull UserHostmask userHostmask, User user) {
+	public JoinEvent(PircBotX bot, @NonNull Channel channel, @NonNull UserHostmask userHostmask, User user, ImmutableMap<String, String> tags) {
 		super(bot);
 		this.channel = channel;
 		this.user = user;
 		this.userHostmask = userHostmask;
+    this.tags = tags;
 	}
 
 	/**

--- a/src/main/java/org/pircbotx/hooks/events/KickEvent.java
+++ b/src/main/java/org/pircbotx/hooks/events/KickEvent.java
@@ -17,6 +17,7 @@
  */
 package org.pircbotx.hooks.events;
 
+import com.google.common.collect.ImmutableMap;
 import javax.annotation.Nullable;
 import org.pircbotx.Channel;
 import org.pircbotx.User;
@@ -74,9 +75,14 @@ public class KickEvent extends Event implements GenericChannelModeRecipientEvent
 	 * The reason given by the user who performed the kick.
 	 */
 	protected final String reason;
+	/**
+	 * The IrcV3 tags
+	 */
+	protected final ImmutableMap<String, String> tags;
 
 	public KickEvent(PircBotX bot, @NonNull Channel channel, @NonNull UserHostmask userHostmask, User user,
-			@NonNull UserHostmask recipientHostmask, User recipient, @NonNull String reason) {
+			@NonNull UserHostmask recipientHostmask, User recipient, @NonNull String reason,
+      ImmutableMap<String, String> tags) {
 		super(bot);
 		this.channel = channel;
 		this.userHostmask = userHostmask;
@@ -84,6 +90,7 @@ public class KickEvent extends Event implements GenericChannelModeRecipientEvent
 		this.recipientHostmask = recipientHostmask;
 		this.recipient = recipient;
 		this.reason = reason;
+		this.tags = tags;
 	}
 
 	/**

--- a/src/main/java/org/pircbotx/hooks/events/ModeEvent.java
+++ b/src/main/java/org/pircbotx/hooks/events/ModeEvent.java
@@ -17,6 +17,7 @@
  */
 package org.pircbotx.hooks.events;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableList;
 import javax.annotation.Nullable;
 import org.pircbotx.Channel;
@@ -69,15 +70,21 @@ public class ModeEvent extends Event implements GenericChannelUserEvent {
 	 */
 	protected final String mode;
 	protected final ImmutableList<String> modeParsed;
+	/**
+	 * The IrcV3 tags
+	 */
+	protected final ImmutableMap<String, String> tags;
 
 	public ModeEvent(PircBotX bot, @NonNull Channel channel, UserHostmask userHostmask,
-			User user, @NonNull String mode, @NonNull ImmutableList<String> modeParsed) {
+			User user, @NonNull String mode, @NonNull ImmutableList<String> modeParsed,
+      ImmutableMap<String, String> tags) {
 		super(bot);
 		this.channel = channel;
 		this.userHostmask = userHostmask;
 		this.user = user;
 		this.mode = mode;
 		this.modeParsed = modeParsed;
+		this.tags = tags;
 	}
 
 	/**

--- a/src/main/java/org/pircbotx/hooks/events/NickChangeEvent.java
+++ b/src/main/java/org/pircbotx/hooks/events/NickChangeEvent.java
@@ -17,6 +17,7 @@
  */
 package org.pircbotx.hooks.events;
 
+import com.google.common.collect.ImmutableMap;
 import javax.annotation.Nullable;
 import org.pircbotx.User;
 import lombok.Data;
@@ -58,14 +59,19 @@ public class NickChangeEvent extends Event implements GenericUserEvent {
 			@Override,
 			@Nullable}))
 	protected final User user;
+	/**
+	 * The IrcV3 tags
+	 */
+	protected final ImmutableMap<String, String> tags;
 
 	public NickChangeEvent(PircBotX bot, @NonNull String oldNick, @NonNull String newNick,
-			@NonNull UserHostmask userHostmask, User user) {
+			@NonNull UserHostmask userHostmask, User user, ImmutableMap<String, String> tags) {
 		super(bot);
 		this.oldNick = oldNick;
 		this.newNick = newNick;
 		this.userHostmask = userHostmask;
 		this.user = user;
+		this.tags = tags;
 	}
 
 	/**

--- a/src/main/java/org/pircbotx/hooks/events/PartEvent.java
+++ b/src/main/java/org/pircbotx/hooks/events/PartEvent.java
@@ -17,6 +17,7 @@
  */
 package org.pircbotx.hooks.events;
 
+import com.google.common.collect.ImmutableMap;
 import org.pircbotx.PircBotX;
 import org.pircbotx.UserHostmask;
 import org.pircbotx.hooks.Event;
@@ -71,8 +72,13 @@ public class PartEvent extends Event implements GenericChannelUserEvent, Generic
 	 */
 	protected final String reason;
 
+	/**
+	 * The IrcV3 tags
+	 */
+	protected final ImmutableMap<String, String> tags;
+
 	public PartEvent(PircBotX bot, UserChannelDaoSnapshot daoSnapshot, ChannelSnapshot channel, @NonNull String channelName,
-			@NonNull UserHostmask userHostmask, UserSnapshot user, @NonNull String reason) {
+			@NonNull UserHostmask userHostmask, UserSnapshot user, @NonNull String reason, ImmutableMap<String, String> tags) {
 		super(bot);
 		this.userChannelDaoSnapshot = daoSnapshot;
 		this.channel = channel;
@@ -80,6 +86,7 @@ public class PartEvent extends Event implements GenericChannelUserEvent, Generic
 		this.userHostmask = userHostmask;
 		this.user = user;
 		this.reason = reason;
+		this.tags = tags;
 	}
 
 	/**

--- a/src/main/java/org/pircbotx/hooks/events/QuitEvent.java
+++ b/src/main/java/org/pircbotx/hooks/events/QuitEvent.java
@@ -17,6 +17,8 @@
  */
 package org.pircbotx.hooks.events;
 
+import com.google.common.collect.ImmutableMap;
+
 import org.pircbotx.PircBotX;
 import org.pircbotx.UserHostmask;
 import org.pircbotx.hooks.Event;
@@ -56,14 +58,20 @@ public class QuitEvent extends Event implements GenericUserEvent, GenericSnapsho
 	 * The reason the user quit from the server.
 	 */
 	protected final String reason;
+	/**
+	 * The IrcV3 tags
+	 */
+	protected final ImmutableMap<String, String> tags;
 
 	public QuitEvent(PircBotX bot, UserChannelDaoSnapshot userChannelDaoSnapshot,
-			@NonNull UserHostmask userHostmask, UserSnapshot user, @NonNull String reason) {
+			@NonNull UserHostmask userHostmask, UserSnapshot user, @NonNull String reason,
+      ImmutableMap<String, String> tags) {
 		super(bot);
 		this.userChannelDaoSnapshot = userChannelDaoSnapshot;
 		this.userHostmask = userHostmask;
 		this.user = user;
 		this.reason = reason;
+		this.tags = tags;
 	}
 
 	/**

--- a/src/main/java/org/pircbotx/hooks/events/TopicEvent.java
+++ b/src/main/java/org/pircbotx/hooks/events/TopicEvent.java
@@ -17,6 +17,8 @@
  */
 package org.pircbotx.hooks.events;
 
+import com.google.common.collect.ImmutableMap;
+
 import org.pircbotx.Channel;
 import org.pircbotx.PircBotX;
 import org.pircbotx.UserHostmask;
@@ -64,8 +66,13 @@ public class TopicEvent extends Event implements GenericChannelEvent {
 	 * When the topic was set (milliseconds since the epoch).
 	 */
 	protected final long date;
+	/**
+	 * The IrcV3 tags
+	 */
+	protected final ImmutableMap<String, String> tags;
 
-	public TopicEvent(PircBotX bot, @NonNull Channel channel, String oldTopic, @NonNull String topic, @NonNull UserHostmask user, long date, boolean changed) {
+	public TopicEvent(PircBotX bot, @NonNull Channel channel, String oldTopic, @NonNull String topic, @NonNull UserHostmask user, long date, boolean changed,
+      ImmutableMap<String, String> tags) {
 		super(bot);
 		this.channel = channel;
 		this.oldTopic = oldTopic;
@@ -73,6 +80,7 @@ public class TopicEvent extends Event implements GenericChannelEvent {
 		this.user = user;
 		this.changed = changed;
 		this.date = date;
+		this.tags = tags;
 	}
 
 	/**

--- a/src/main/java/org/pircbotx/hooks/events/UserModeEvent.java
+++ b/src/main/java/org/pircbotx/hooks/events/UserModeEvent.java
@@ -17,6 +17,7 @@
  */
 package org.pircbotx.hooks.events;
 
+import com.google.common.collect.ImmutableMap;
 import javax.annotation.Nullable;
 import org.pircbotx.User;
 import lombok.Data;
@@ -64,15 +65,21 @@ public class UserModeEvent extends Event implements GenericUserModeEvent {
 	 * The mode that has been set.
 	 */
 	protected final String mode;
+	/**
+	 * The IrcV3 tags
+	 */
+	protected final ImmutableMap<String, String> tags;
 
 	public UserModeEvent(PircBotX bot, @NonNull UserHostmask userHostmask, User user,
-			@NonNull UserHostmask recipientHostmask, User recipient, @NonNull String mode) {
+			@NonNull UserHostmask recipientHostmask, User recipient, @NonNull String mode,
+      ImmutableMap<String, String> tags) {
 		super(bot);
 		this.userHostmask = user;
 		this.user = user;
 		this.recipientHostmask = recipientHostmask;
 		this.recipient = recipient;
 		this.mode = mode;
+		this.tags = tags;
 	}
 
 	/**


### PR DESCRIPTION
We're already parsing these tags, but we were only putting them into
MessageEvent and PrivateMessageEvent. This just updates all the other
events to also store the tags.

I'm using this in combination with the `account-tag` capability to
associate user accounts to each of these events without needing to do a
whois. This is so much more efficient.