### PR TITLE
This "should" fix the outdated maven version on jitpack.

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,5 @@
+before_install:
+  - source "$HOME/.sdkman/bin/sdkman-init.sh"
+  - sdk update
+  - sdk install maven
+  - mvn -v


### PR DESCRIPTION
Also see issue #408

However due to the nature of Jitpack it will only fix future builds, since this file does not exist in previous builds.
You could work with a maven wrapper, but this only adds more unnecessary files to the project.