### PR TITLE
updated jdk on jitpack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,27 @@
+#
+# Copyright (C) 2010-2022 The PircBotX Project Authors
+#
+# This file is part of PircBotX.
+#
+# PircBotX is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# PircBotX is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# PircBotX. If not, see <http://www.gnu.org/licenses/>.
+#
+jdk:
+  - openjdk17
+
 before_install:
   - source "$HOME/.sdkman/bin/sdkman-init.sh"
   - sdk update
   - sdk install maven
+  - sdk install java 17.0.4.1-tem
+  - sdk use java 17.0.4.1-tem
   - mvn -v


### PR DESCRIPTION
updated jdk on jitpackas the release tag on the maven compiler plugin only works with versions higher than 8