### PR TITLE
Bump commons-text from 1.9 to 1.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-text</artifactId>
-			<version>1.9</version>
+			<version>1.10.0</version>
 		</dependency>
 		<!-- Slf4j for logging -->
 		<dependency>


### PR DESCRIPTION
Let's not pull in 1.9 due to [CVE-2022-42889](https://www.cve.org/CVERecord?id=CVE-2022-42889).