### PR TITLE
Fix populating user hostmasks on WHO and fix CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
-				<version>1.7.36</version>
+				<version>2.0.16</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.code.findbugs</groupId>

--- a/src/main/java/org/pircbotx/Configuration.java
+++ b/src/main/java/org/pircbotx/Configuration.java
@@ -591,6 +591,7 @@ public class Configuration {
 			this.autoJoinChannels.clear();
 			this.autoJoinChannels.putAll(configuration.getAutoJoinChannels());
 			this.onJoinWhoEnabled = configuration.isOnJoinWhoEnabled();
+			this.onJoinModeEnabled = configuration.isOnJoinModeEnabled();
 			this.identServerEnabled = configuration.isIdentServerEnabled();
 			this.capEnabled = configuration.isCapEnabled();
 			this.capHandlers.clear();

--- a/src/main/java/org/pircbotx/InputParser.java
+++ b/src/main/java/org/pircbotx/InputParser.java
@@ -815,6 +815,7 @@ public class InputParser implements Closeable {
 			User curUser = bot.getUserChannelDao().containsUser(nick) ? bot.getUserChannelDao().getUser(nick) : bot.getConfiguration()
 					.getBotFactory()
 					.createUser(curUserHostmask);
+			curUser.updateHostmask(curUserHostmask);
 
 			
 			


### PR DESCRIPTION
Adds an `curUser.updateHostmask` call in the `RPL_WHOREPLY` handler. Before adding this, when the bot joins the channel with `isOnJoinWhoEnabled` set to `true`, it wasn't updating the hostmasks on users the user DAO already had instances of. This would lead to the bot not knowing the hostmask of users already in the channel before the bot joins until they sent a message or rejoined the channel. This would make implemented commands on the library's consumer like `!addop`, which depend on the user's hostmask, unable to function until this data is populated.

Fixes the CI by adding a missing `isOnJoinModeEnabled` assign in `Configuration.Builder` to resolve a broken test, and updates slf4j-api to 2.0.16 to resolve `LoggingEventAware` not found.