### PR TITLE
Allow DNS resolution through proxy

### DIFF
--- a/src/main/java/org/pircbotx/PircBotX.java
+++ b/src/main/java/org/pircbotx/PircBotX.java
@@ -263,45 +263,47 @@ public class PircBotX implements Comparable<PircBotX>, Closeable {
 				//Hostname and port
 				Utils.addBotToMDC(this);
 				log.info("---Starting Connect attempt {}/{}", connectAttempts, configuration.getAutoReconnectAttempts() + "---");
-
+				InetAddress[] serverAddresses;
 				try {
-					int serverAddressCounter = 0;
-					InetAddress[] serverAddresses = InetAddress.getAllByName(serverHostname);
-					for (InetAddress curAddress : serverAddresses) {
-						serverAddressCounter++;
-						String debug = Utils.format("[{}/{} address left from {}, {}/{} hostnames left] ",
-								String.valueOf(serverAddresses.length - serverAddressCounter),
-								String.valueOf(serverAddresses.length),
-								serverHostname,
-								String.valueOf(configuration.getServers().size() - serverEntryCounter),
-								String.valueOf(configuration.getServers().size())
-						);
-						log.debug("{}Atempting to connect to {} on port {}", debug, curAddress, curServerEntry.getPort());
-						try {
-							socket = configuration.getSocketFactory().createSocket();
-							socket.bind(new InetSocketAddress(configuration.getLocalAddress(), 0));
-							socket.connect(new InetSocketAddress(curAddress, curServerEntry.getPort()), configuration.getSocketConnectTimeout());
-
-							//No exception, assume successful
-							serverPort = curServerEntry.getPort();
-							break ServerEntryLoop;
-						} catch (Exception e) {
-							connectExceptions.put(new InetSocketAddress(curAddress, curServerEntry.getPort()), e);
-							log.warn("{}Failed to connect to {} on port {}",
-									debug,
-									curAddress,
-									curServerEntry.getPort(),
-									e);
-						}
-					}
-				} catch(UnknownHostException e) {
+					serverAddresses = InetAddress.getAllByName(serverHostname);
+				} catch (UnknownHostException hostException) {
 					try {
 						socket = configuration.getSocketFactory().createSocket(serverHostname, curServerEntry.getPort());
 						serverPort = curServerEntry.getPort();
+						break ServerEntryLoop;
 					} catch (Exception ex) {
-						connectExceptions.put(new InetSocketAddress(curServerEntry.getHostname(), curServerEntry.getPort()), e);
+						connectExceptions.put(new InetSocketAddress(curServerEntry.getHostname(), curServerEntry.getPort()), ex);
 						log.warn("Failed to connect to {} on port {}",
 								curServerEntry.getHostname(),
+								curServerEntry.getPort(),
+								ex);
+					}
+					continue;
+				}
+				int serverAddressCounter = 0;
+				for (InetAddress curAddress : serverAddresses) {
+					serverAddressCounter++;
+					String debug = Utils.format("[{}/{} address left from {}, {}/{} hostnames left] ",
+							String.valueOf(serverAddresses.length - serverAddressCounter),
+							String.valueOf(serverAddresses.length),
+							serverHostname,
+							String.valueOf(configuration.getServers().size() - serverEntryCounter),
+							String.valueOf(configuration.getServers().size())
+					);
+					log.debug("{}Atempting to connect to {} on port {}", debug, curAddress, curServerEntry.getPort());
+					try {
+						socket = configuration.getSocketFactory().createSocket();
+						socket.bind(new InetSocketAddress(configuration.getLocalAddress(), 0));
+						socket.connect(new InetSocketAddress(curAddress, curServerEntry.getPort()), configuration.getSocketConnectTimeout());
+
+						//No exception, assume successful
+						serverPort = curServerEntry.getPort();
+						break ServerEntryLoop;
+					} catch (Exception e) {
+						connectExceptions.put(new InetSocketAddress(curAddress, curServerEntry.getPort()), e);
+						log.warn("{}Failed to connect to {} on port {}",
+								debug,
+								curAddress,
 								curServerEntry.getPort(),
 								e);
 					}


### PR DESCRIPTION
Allows the DNS resolution to fallback to the supplied socket factory if it can not be resolved locally.

Fixes https://github.com/pircbotx/pircbotx/issues/427
