### PR TITLE
noticed this bug on away messages for users not in shared channels:

### DIFF
--- a/src/main/java/org/pircbotx/InputParser.java
+++ b/src/main/java/org/pircbotx/InputParser.java
@@ -699,12 +699,15 @@ public class InputParser implements Closeable {
 		} else if (command.equals("INVITE")) {
 			// Somebody is inviting somebody else into a channel.
 			configuration.getListenerManager().onEvent(new InviteEvent(bot, source, sourceUser, message));
-		} else if (command.equals("AWAY"))
-			//IRCv3 AWAY notify
-			if (parsedLine.isEmpty())
-				sourceUser.setAwayMessage("");
-			else
-				sourceUser.setAwayMessage(parsedLine.get(0));
+		} else if (command.equals("AWAY")) {
+			//IRCv3 AWAY notify - sourceUser may be null if user shares no channels with the bot
+			if (sourceUser != null) {
+				if (parsedLine.isEmpty())
+					sourceUser.setAwayMessage("");
+				else
+					sourceUser.setAwayMessage(parsedLine.get(0));
+			}
+		}
 		else
 			// If we reach this point, then we've found something that the PircBotX
 			// Doesn't currently deal with.


### PR DESCRIPTION
java.lang.NullPointerException: Cannot invoke "org.pircbotx.User.setAwayMessage(String)" because "sourceUser" is null at org.pircbotx.InputParser.processCommand(InputParser.java:707) at org.pircbotx.InputParser.handleLine(InputParser.java:430) at org.pircbotx.PircBotX.processNextLine(PircBotX.java:416) at org.pircbotx.PircBotX.startLineProcessing(PircBotX.java:363) at org.pircbotx.PircBotX.connect(PircBotX.java:351) at org.pircbotx.PircBotX.startBot(PircBotX.java:179)